### PR TITLE
Initial implementation - Checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,17 @@
+# gitignore from swift package init
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc
+
+Package.resolved
+
+
 # Xcode
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Package.resolved
 
 ## User settings
 xcuserdata/
+swift-builder.xcscheme
 
 ## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
 *.xcscmblueprint

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,8 @@ let package = Package(
         .package(url: "https://github.com/vapor/console-kit", from: "4.5.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+
+        .package(url: "https://github.com/NikolayJuly/drain-work-pool.git", from: "2.0.0"),
     ],
     targets: [
         .executableTarget(
@@ -26,6 +28,7 @@ let package = Package(
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "ConsoleKit", package: "console-kit"),
+                .product(name: "WorkPoolDraning", package: "drain-work-pool"),
                 "Shell",
             ]),
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "swift-builder",
     platforms: [
-        .macOS(.v12),
+        .macOS(.v13),
     ],
     products: [
         .executable(
@@ -16,14 +16,17 @@ let package = Package(
             ]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/vapor/console-kit", from: "4.5.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],
     targets: [
         .executableTarget(
             name: "SwiftBuilder",
             dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "ConsoleKit", package: "console-kit"),
+                "Shell",
             ]),
         .target(
             name: "Shell",

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version: 5.7
+
+import PackageDescription
+
+let package = Package(
+    name: "swift-builder",
+    platforms: [
+        .macOS(.v12),
+    ],
+    products: [
+        .executable(
+            name: "SwiftBuilder",
+            targets: [
+                "SwiftBuilder",
+                "Shell"
+            ]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        .package(url: "https://github.com/vapor/console-kit", from: "4.5.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "SwiftBuilder",
+            dependencies: [
+                .product(name: "ConsoleKit", package: "console-kit"),
+            ]),
+        .target(
+            name: "Shell",
+            dependencies: [
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "ConsoleKit", package: "console-kit"),
+            ]),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -16,10 +16,14 @@ let package = Package(
             ]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/console-kit", from: "4.5.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
 
+        // Log + Console
+        .package(url: "https://github.com/crspybits/swift-log-file.git", from: "0.1.0"),
+        .package(url: "https://github.com/vapor/console-kit", from: "4.5.0"),
+
+        // Tools
         .package(url: "https://github.com/NikolayJuly/drain-work-pool.git", from: "2.0.0"),
     ],
     targets: [
@@ -28,6 +32,7 @@ let package = Package(
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "ConsoleKit", package: "console-kit"),
+                .product(name: "FileLogging", package: "swift-log-file"),
                 .product(name: "WorkPoolDraning", package: "drain-work-pool"),
                 "Shell",
             ]),

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # swift-toolchain-for-android-on-macos
+
 Swift toolchain for android on macos
+
+## How to update code fore new release
+
+1. Find new release tag in (github repo)[https://github.com/apple/swift.git]
+2. Follow steps [here](./Sources/SwiftBuilder/Repos/HowToGetCommitHashes.md) to update default checkout hashes
+3. Execute and fix issue by issue...

--- a/Sources/Shell/AsyncBytesToLines.swift
+++ b/Sources/Shell/AsyncBytesToLines.swift
@@ -1,0 +1,147 @@
+import Foundation
+
+/// Class receives bytes of data, data must be utf8 representation of mutiline string
+/// At the end, we need to call  `complete`, to decode last line, which might not end with "\n"
+/// This implementation is attempt to repoduce usefull `AsyncBytes` from `URLSession` or `FileHandler`
+final class AsyncBytesToLines: AsyncSequence {
+
+    typealias Element = String
+
+    struct AsyncIterator: AsyncIteratorProtocol {
+
+        typealias Element = String
+
+        init(_ asyncBytes: AsyncBytesToLines) {
+            self.asyncBytes = asyncBytes
+        }
+
+        mutating func next() async -> String? {
+            return await withCheckedContinuation { continuation in
+                asyncBytes.lock.lock()
+                defer { asyncBytes.lock.unlock() }
+                if count < asyncBytes.lines.count {
+                    defer { count += 1 }
+                    continuation.resume(with: .success(asyncBytes.lines[count]))
+                    return
+                }
+
+                guard asyncBytes.expectingBytes else {
+                    continuation.resume(with: .success(nil))
+                    return
+                }
+
+
+                let oldCounter = count
+                count += 1
+
+                asyncBytes.updateWaiters.append { [self] in
+                    self.asyncBytes.lock.lock()
+                    defer { self.asyncBytes.lock.unlock() }
+                    if oldCounter < asyncBytes.lines.count {
+                        continuation.resume(with: .success(asyncBytes.lines[oldCounter]))
+                        return
+                    }
+                    guard asyncBytes.expectingBytes else {
+                        continuation.resume(with: .success(nil))
+                        return
+                    }
+
+                    fatalError("In this block we expect or new value or end of bytes")
+                }
+            }
+        }
+
+        private let asyncBytes: AsyncBytesToLines
+        private var count = 0
+    }
+
+    func add(_ bytes: some Sequence<UInt8>) {
+
+        let waiters: [UpdateWaiter]
+        do {
+            lock.lock()
+            defer { lock.unlock() }
+            guard expectingBytes else {
+                fatalError("We do not expect more bytes")
+            }
+            notProcessedBytes.append(contentsOf: bytes)
+            var didAddAtLeastOneLine = false
+            while true {
+                let `continue` = processCurrentBytes()
+                guard `continue` else {
+                    break
+                }
+                didAddAtLeastOneLine = true
+            }
+
+
+            if didAddAtLeastOneLine {
+                waiters = self.updateWaiters
+                self.updateWaiters.removeAll()
+            } else {
+                waiters = []
+            }
+        }
+
+        waiters.forEach { $0() }
+    }
+
+    func complete() {
+        lock.lock()
+        expectingBytes = false
+        let line = String(bytes: notProcessedBytes, encoding: .utf8)!
+        notProcessedBytes.removeAll()
+        let newLines = line.components(separatedBy: "\n")
+        lines.append(contentsOf: newLines)
+        let waiters: [UpdateWaiter] = self.updateWaiters
+        self.updateWaiters.removeAll()
+        lock.unlock()
+        waiters.forEach { $0() }
+    }
+
+    // MARK: AsyncSequence
+
+    func makeAsyncIterator() -> AsyncIterator {
+        AsyncIterator(self)
+    }
+
+    // MARK: Private
+
+    private typealias UpdateWaiter = () -> Void
+
+    private let lock = NSLock()
+    private var notProcessedBytes = [UInt8]()
+    private var lines = [String]()
+    private var expectingBytes = true
+
+    private var updateWaiters = [UpdateWaiter]()
+
+    /// - returns: true, if new line was generated
+    private func processCurrentBytes() -> Bool {
+        guard notProcessedBytes.count > 1 else {
+            return false
+        }
+
+        let separatorBytes = "\n".data(using: .utf8)!
+
+        precondition(separatorBytes.count == 1)
+
+        let newLineByte = separatorBytes.first!
+
+        let firstIndex = notProcessedBytes.firstIndex(of: newLineByte)
+
+        guard let firstIndex else {
+            return false
+        }
+
+        let lineBytes = notProcessedBytes.prefix(firstIndex)
+        let line = String(bytes: lineBytes, encoding: .utf8)!
+
+        let subSequence = notProcessedBytes.dropFirst(firstIndex + 1)
+        notProcessedBytes = Array(subSequence)
+
+        lines.append(line)
+        return true
+    }
+}
+

--- a/Sources/Shell/AsyncBytesToLines.swift
+++ b/Sources/Shell/AsyncBytesToLines.swift
@@ -30,7 +30,6 @@ final class AsyncBytesToLines: AsyncSequence {
                     return
                 }
 
-
                 let oldCounter = count
                 count += 1
 
@@ -73,7 +72,6 @@ final class AsyncBytesToLines: AsyncSequence {
                 }
                 didAddAtLeastOneLine = true
             }
-
 
             if didAddAtLeastOneLine {
                 waiters = self.updateWaiters

--- a/Sources/Shell/Git/GitClone.swift
+++ b/Sources/Shell/Git/GitClone.swift
@@ -5,13 +5,13 @@ public actor GitClone {
     /// - parameters:
     ///     - source: git repo url
     ///     - destination: folder URL
-    public init(source: URL, destination: URL) {
+    public init(source: URL, destination: URL, logger: Logger) {
         self.source = source
         self.destination = destination
+        self.logger = logger
     }
 
     public func execute() async throws {
-        let logger = Logger(label: "Git Checkout Logger") { _ in CloneLogger() }
         let command = ShellCommand("git", "clone", "--progress", source.absoluteString, destination.path, logger: logger)
         _ = try await command.execute()
     }
@@ -20,26 +20,5 @@ public actor GitClone {
 
     private let source: URL
     private let destination: URL
+    private let logger: Logger
 }
-
-private struct CloneLogger: LogHandler {
-    subscript(metadataKey key: String) -> Logger.Metadata.Value? {
-        get { self.metadata[key] }
-        set { self.metadata[key] = newValue }
-    }
-    
-    var metadata: Logger.Metadata = [:]
-    
-    var logLevel: Logger.Level = .info
-
-    func log(level: Logger.Level,
-             message: Logger.Message,
-             metadata: Logger.Metadata?,
-             source: String,
-             file: String,
-             function: String,
-             line: UInt) {
-        print(message)
-    }
-}
-

--- a/Sources/Shell/Git/GitClone.swift
+++ b/Sources/Shell/Git/GitClone.swift
@@ -5,6 +5,7 @@ public actor GitClone {
     /// - parameters:
     ///     - source: git repo url
     ///     - destination: folder URL
+    ///     - logger: command output logger
     public init(source: URL, destination: URL, logger: Logger) {
         self.source = source
         self.destination = destination

--- a/Sources/Shell/Git/GitClone.swift
+++ b/Sources/Shell/Git/GitClone.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Logging
+
+public actor GitClone {
+    /// - parameters:
+    ///     - source: git repo url
+    ///     - destination: folder URL
+    public init(source: URL, destination: URL) {
+        self.source = source
+        self.destination = destination
+    }
+
+    public func execute() async throws {
+        let logger = Logger(label: "Git Checkout Logger") { _ in CloneLogger() }
+        let command = ShellCommand("git", "clone", "--progress", source.absoluteString, destination.path, logger: logger)
+        _ = try await command.execute()
+    }
+
+    // MARK: Private
+
+    private let source: URL
+    private let destination: URL
+}
+
+private struct CloneLogger: LogHandler {
+    subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+        get { self.metadata[key] }
+        set { self.metadata[key] = newValue }
+    }
+    
+    var metadata: Logger.Metadata = [:]
+    
+    var logLevel: Logger.Level = .info
+
+    func log(level: Logger.Level,
+             message: Logger.Message,
+             metadata: Logger.Metadata?,
+             source: String,
+             file: String,
+             function: String,
+             line: UInt) {
+        print(message)
+    }
+}
+

--- a/Sources/Shell/ShellCommand.swift
+++ b/Sources/Shell/ShellCommand.swift
@@ -5,6 +5,7 @@ public enum ShellCommandError: Error {
     case nonZeroCode(Int32, String?, String?) // status code, error, output
 }
 
+/// - note: This actor execute commands, to execute script you need to delete`["-c", "-l"]` from `task.arguments`
 public actor ShellCommand {
 
     /// - parameter command: command itself and arguments, , for example ShellCommand(["ls", "-la"], ..)

--- a/Sources/Shell/ShellCommand.swift
+++ b/Sources/Shell/ShellCommand.swift
@@ -51,7 +51,7 @@ public actor ShellCommand {
         }
 
         let commandString = wrappedCommand.joined(separator: " ")
-        logger.debug("Executing \(commandString)")
+        logger.info("Executing command: \(commandString)")
 
         task.standardOutput = pipe
         task.standardError = errorPipe
@@ -110,7 +110,7 @@ public actor ShellCommand {
         pipe.fileHandleForReading.readabilityHandler = nil
         errorPipe.fileHandleForReading.readabilityHandler = nil
 
-        let restOfStdOut =  try errorPipe.fileHandleForReading.readToEnd() ?? Data()
+        let restOfStdOut = try errorPipe.fileHandleForReading.readToEnd() ?? Data()
         stdOutLines.add(restOfStdOut)
         stdOutLines.complete()
 

--- a/Sources/Shell/ShellCommand.swift
+++ b/Sources/Shell/ShellCommand.swift
@@ -8,7 +8,7 @@ public enum ShellCommandError: Error {
 /// - note: This actor execute commands, to execute script you need to delete`["-c", "-l"]` from `task.arguments`
 public actor ShellCommand {
 
-    /// - parameter command: command itself and arguments, , for example ShellCommand(["ls", "-la"], ..)
+    /// - parameter command: command itself and arguments, for example ShellCommand(["ls", "-la"], ..)
     public init(_ command: [String],
                 currentDirectoryURL: URL? = nil,
                 environment: [String: String]? = nil,

--- a/Sources/Shell/ShellCommand.swift
+++ b/Sources/Shell/ShellCommand.swift
@@ -1,0 +1,151 @@
+import Foundation
+import Logging
+
+public enum ShellCommandError: Error {
+    case nonZeroCode(Int32, String?, String?) // status code, error, output
+}
+
+public actor ShellCommand {
+
+    /// - parameter command: command itself and arguments, , for example ShellCommand(["ls", "-la"], ..)
+    public init(_ command: [String],
+                currentDirectoryURL: URL? = nil,
+                environment: [String: String]? = nil,
+                logger: Logger) {
+        self.command = command
+        self.currentDirectoryURL = currentDirectoryURL
+        self.environment = environment
+        self.logger = logger
+    }
+
+    /// - parameter command: command itself and arguments, for example ShellCommand("ls", "-la", ...)
+    public init(_ command: String ...,
+                currentDirectoryURL: URL? = nil,
+                environment: [String: String]? = nil,
+                logger: Logger) {
+        self.command = command
+        self.currentDirectoryURL = currentDirectoryURL
+        self.environment = environment
+        self.logger = logger
+    }
+
+    /// If no output - empty srting will be returned
+    @discardableResult
+    public func execute() async throws -> String {
+        let task = Process()
+        let pipe = Pipe()
+        let errorPipe = Pipe()
+
+        // If we have command part with space inside, but it is not wrapped with "", we will enforce it
+        let wrappedCommand = command.map { commandPart in
+            guard commandPart.contains(" ") else {
+                return commandPart
+            }
+
+            guard commandPart.hasPrefix("\"") == false else {
+                return commandPart
+            }
+
+            return "\"" + commandPart + "\""
+        }
+
+        let commandString = wrappedCommand.joined(separator: " ")
+        logger.debug("Executing \(commandString)")
+
+        task.standardOutput = pipe
+        task.standardError = errorPipe
+        task.arguments = ["-c", "-l"] + [commandString]
+        task.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        task.standardInput = nil
+
+        if let currentDirectoryURL = currentDirectoryURL {
+            task.currentDirectoryURL = currentDirectoryURL
+        }
+
+        if let environment = environment {
+            task.environment = environment
+        }
+
+        let stdOutLines = AsyncBytesToLines()
+        let errOutLines = AsyncBytesToLines()
+
+        pipe.fileHandleForReading.readabilityHandler = { fileHandler in
+            let availableData = fileHandler.availableData
+            guard availableData.isEmpty == false else {
+                return
+            }
+
+            stdOutLines.add(availableData)
+        }
+
+        errorPipe.fileHandleForReading.readabilityHandler = { fileHandler in
+            let availableData = fileHandler.availableData
+            guard availableData.isEmpty == false else {
+                return
+            }
+            errOutLines.add(availableData)
+        }
+
+        let stdOutputTask = Task {
+            for await line in stdOutLines {
+                stdOut.append(line)
+                logger.info("\(line)")
+            }
+        }
+
+        let errorOutputTask = Task {
+            for await line in errOutLines {
+                errorOut.append(line)
+                logger.error("\(line)")
+            }
+        }
+
+        try task.run()
+
+        await withCheckedContinuation { [task] continuation in
+            task.asyncWait(continuation: continuation)
+        }
+
+        pipe.fileHandleForReading.readabilityHandler = nil
+        errorPipe.fileHandleForReading.readabilityHandler = nil
+
+        let restOfStdOut =  try errorPipe.fileHandleForReading.readToEnd() ?? Data()
+        stdOutLines.add(restOfStdOut)
+        stdOutLines.complete()
+
+        let restOfErrOut = try errorPipe.fileHandleForReading.readToEnd() ?? Data()
+        errOutLines.add(restOfErrOut)
+        errOutLines.complete()
+
+        _ = await (stdOutputTask.result, errorOutputTask.result)
+
+        let output = stdOut.joined(separator: "\n")
+
+        guard task.terminationStatus == 0 else {
+            let errorOutput = errorOut.joined(separator: "\n")
+            throw ShellCommandError.nonZeroCode(task.terminationStatus, errorOutput, output)
+        }
+
+        return output
+    }
+
+    // MARK: Private
+
+    private let command: [String]
+    private let currentDirectoryURL: URL?
+    private let environment: [String: String]?
+    private let logger: Logger
+
+    private var stdOut = [String]()
+    private var errorOut = [String]()
+}
+
+private extension Process {
+    // Hack to avoid warning "Capture of 'task' with non-sendable type 'Process' in a `@Sendable` closure"
+    func asyncWait(continuation: CheckedContinuation<(), Never>) {
+        DispatchQueue.global().async {
+            self.waitUntilExit()
+            continuation.resume()
+        }
+    }
+}

--- a/Sources/SwiftBuilder/Extension/DictionaryExtension.swift
+++ b/Sources/SwiftBuilder/Extension/DictionaryExtension.swift
@@ -2,6 +2,8 @@ import Foundation
 
 extension Dictionary where Value: Comparable {
 
+    /// If `value` less than `self[key]` - do nothing, discarding `value`
+    /// `nil` smaller than any `value`
     @inlinable
     mutating func increase(to value: Value, for key: Key) {
         guard let existing = self[key] else {

--- a/Sources/SwiftBuilder/Extension/DictionaryExtension.swift
+++ b/Sources/SwiftBuilder/Extension/DictionaryExtension.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension Dictionary where Value: Comparable {
+
+    @inlinable
+    mutating func increase(to value: Value, for key: Key) {
+        guard let existing = self[key] else {
+            self[key] = value
+            return
+        }
+
+        self[key] = Swift.max(existing, value)
+    }
+}

--- a/Sources/SwiftBuilder/Extension/FileManagerExtension.swift
+++ b/Sources/SwiftBuilder/Extension/FileManagerExtension.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+extension FileManager {
+    func fileExists(at fileUrl: URL) -> Bool {
+        var isDir: ObjCBool = false
+        let exists = fileExists(atPath: fileUrl.path, isDirectory: &isDir)
+
+        return exists && !isDir.boolValue
+    }
+
+    func folderExists(at folderUrl: URL) -> Bool {
+        var isDir: ObjCBool = false
+        let folderExists = fileExists(atPath: folderUrl.path, isDirectory: &isDir)
+
+        return folderExists && isDir.boolValue
+    }
+
+    func createEmptyFolder(at folderUrl: URL) throws {
+        try? removeItem(at: folderUrl)
+        try createDirectory(at: folderUrl, withIntermediateDirectories: false, attributes: nil)
+    }
+
+    func createFolderIfNotExists(at folderUrl: URL) throws {
+        guard !folderExists(at: folderUrl) else {
+            return
+        }
+
+        do {
+            try createDirectory(at: folderUrl, withIntermediateDirectories: false, attributes: nil)
+        } catch let exc {
+            throw "Failed to create fodler at \(folderUrl.absoluteURL): \(exc)"
+        }
+    }
+}

--- a/Sources/SwiftBuilder/Extension/StringExtension.swift
+++ b/Sources/SwiftBuilder/Extension/StringExtension.swift
@@ -3,7 +3,7 @@ import Foundation
 extension String: LocalizedError { }
 
 extension String {
-    /// Should be called on filename, not path. Will remove last '.ext' (any extension)
+    /// Should be called on filename, not path. Will remove last '.ext'
     var fileNameByRemovingExtension: String {
         let components = self.components(separatedBy: ".")
         guard components.count > 1 else {

--- a/Sources/SwiftBuilder/Extension/StringExtension.swift
+++ b/Sources/SwiftBuilder/Extension/StringExtension.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension String: LocalizedError { }
+
+extension String {
+    /// Should be called on filename, not path. Will remove last '.ext' (any extension)
+    var fileNameByRemovingExtension: String {
+        let components = self.components(separatedBy: ".")
+        guard components.count > 1 else {
+            return self
+        }
+
+        return components.prefix(components.count - 1).joined(separator: ".")
+    }
+}

--- a/Sources/SwiftBuilder/Repos/DefaultRevisionsMap.swift
+++ b/Sources/SwiftBuilder/Repos/DefaultRevisionsMap.swift
@@ -1,9 +1,16 @@
 import Foundation
+import RegexBuilder
 
 // TODO: Consider outomate retriving of `updateChekcoutOutput`
 struct DefaultRevisionsMap {
     init() {
-        fatalError("Implement parsing with regex")
+        let matches = updateChekcoutOutput.matches(of: revisionLineRegex)
+
+        var parsedMap = [String: CheckoutRevision]()
+        for match in matches {
+            parsedMap[match.output.1] = .commit(match.output.2)
+        }
+        self.parsedMap = parsedMap
     }
 
     subscript(_ repoName: String) -> CheckoutRevision? {
@@ -55,3 +62,26 @@ swift-xcode-playground-support     : dd0d8c8d121d2f20664e4779a3d29482a55908bb
 swiftpm                            : 7b898e6cad75a3c096ad947508eb948ad5f614d4
 yams                               : 00c403debcd0a007b854bb35e598466207a2d58c
 """
+
+private let repoNameRegex = Regex {
+    OneOrMore(.word)
+    Repeat(0...) {
+        "-"
+        OneOrMore(.word)
+    }
+}
+private let revisionLineRegex = Regex {
+    ZeroOrMore(.whitespace)
+    Capture {
+        repoNameRegex
+    } transform: { v -> String in
+        String(v)
+    }
+    OneOrMore(.whitespace)
+    ": "
+    Capture {
+        OneOrMore(.hexDigit)
+    } transform: { v -> String in
+        String(v)
+    }
+}

--- a/Sources/SwiftBuilder/Repos/DefaultRevisionsMap.swift
+++ b/Sources/SwiftBuilder/Repos/DefaultRevisionsMap.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+// TODO: Consider outomate retriving of `updateChekcoutOutput`
+struct DefaultRevisionsMap {
+    init() {
+        fatalError("Implement parsing with regex")
+    }
+
+    subscript(_ repoName: String) -> CheckoutRevision? {
+        parsedMap[repoName]
+    }
+
+    // MARK: Private
+
+    private let parsedMap: [String: CheckoutRevision]
+}
+
+private let updateChekcoutOutput =
+"""
+cmake                              : skip
+cmark                              : 9c8096a23f44794bde297452d87c455fc4f76d42
+icu                                : skip
+indexstore-db                      : 9305648b0a8700434fa2e55eeacf7c7f4402a0d5
+llbuild                            : 564424db5fdb62dcb5d863bdf7212500ef03a87b
+llvm-project                       : 3dade082a9b1989207a7fa7f3975868485d16a49
+ninja                              : 448ae1ccacd17025457ace965d78a45a113c70c6
+sourcekit-lsp                      : 849de8fbb8248623701ef614da015408ef114f1c
+swift                              : 50794e1ae31a08b492cc717ead6f99e7d6932e21
+swift-argument-parser              : e394bf350e38cb100b6bc4172834770ede1b7232
+swift-atomics                      : 919eb1d83e02121cdb434c7bfc1f0c66ef17febe
+swift-cmark-gfm                    : 9c8096a23f44794bde297452d87c455fc4f76d42
+swift-collections                  : 2d33a0ea89c961dcb2b3da2157963d9c0370347e
+swift-corelibs-foundation          : a87d185cecfc50086a592852bae223d5ec214cea
+swift-corelibs-libdispatch         : b602cbb26c5cee1aac51021aa2cd6a30a03b1bd3
+swift-corelibs-xctest              : 56501e765303ccac2f104a6e45cfcd6e733cc74e
+swift-crypto                       : 0141f53dd525706c803b0c20aa8ad36f9ecd45e5
+swift-docc                         : 220803435350ea9ff03902fbbc227667867224b9
+swift-docc-render-artifact         : 728d974c5f479fac3fdb5ade09f4d3c3ea1a170a
+swift-docc-symbolkit               : 8682202025906dce29a8b04f9263f40ba87b89d8
+swift-driver                       : 719426df790661020de657bf38beb2a8b1de5ad3
+swift-experimental-string-processing: 6340818cbfc85b8469c22fa8735c8337c137a7fa
+swift-format                       : bd89f0d9da6256d1d23524ef0f9b5197751af013
+swift-installer-scripts            : 7e916a0f3eb9d5a71a65b8b2af0d1871ca6b2eb2
+swift-integration-tests            : 3156cf37ab7c307cc92bb76f2a5e8236cef7d060
+swift-lmdb                         : 6ea45a7ebf6d8f72bd299dfcc3299e284bbb92ee
+swift-markdown                     : d6cd065a7e4b6c3fad615dcd39890e095a2f63a2
+swift-nio                          : 1d425b0851ffa2695d488cce1d68df2539f42500
+swift-nio-ssl                      : 2e74773972bd6254c41ceeda827f229bccbf1c0f
+swift-numerics                     : 0a23770641f65a4de61daf5425a37ae32a3fd00d
+swift-stress-tester                : 8275f723e7167c246d95aea26c07fef13ce15486
+swift-syntax                       : 9716bcb42480438a051d68c9860d9ed6cb0fbbb1
+swift-system                       : 836bc4557b74fe6d2660218d56e3ce96aff76574
+swift-tools-support-core           : 184eba382f6abbb362ffc02942d790ff35019ad4
+swift-xcode-playground-support     : dd0d8c8d121d2f20664e4779a3d29482a55908bb
+swiftpm                            : 7b898e6cad75a3c096ad947508eb948ad5f614d4
+yams                               : 00c403debcd0a007b854bb35e598466207a2d58c
+"""

--- a/Sources/SwiftBuilder/Repos/HowToGetCommitHashes.md
+++ b/Sources/SwiftBuilder/Repos/HowToGetCommitHashes.md
@@ -1,0 +1,11 @@
+#  How To Get Commit Hashes
+
+- Checkout or download any revision of [swift repo](https://github.com/apple/swift/)
+- Create empty folder and put swift repo there, for example to `~/ws/swift-checkout/swift-5.7-RELEASE`.
+- `$ cd ~/ws/swift-checkout/swift-5.7-RELEASE && utils/update-checkout --clone-with-ssh --tag swift-5.7-RELEASE`. It will checkout all needed repos. In the end you will get output with all revisions. Replace `swift-swift-5.7-RELEASE` with needed release tag.
+- Replace ``updateChekcoutOutput`` from `DefaultRevisionsMap.swift` with output of `utils/update-checkout`
+  
+ 
+This process take some time, but ideally needed only once per release 
+
+

--- a/Sources/SwiftBuilder/Repos/Repos.swift
+++ b/Sources/SwiftBuilder/Repos/Repos.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+enum Repos {
+    static let allRepos: [Checkoutable] = [
+        SwiftRepo(),
+        LlvmProjectRepo(),
+        CMarkRepo(),
+        YamsRepo(),
+        SwiftArgumentParserRepo(),
+        SwiftSystemRepo(),
+        SwiftLLBuildCoreRepo(),
+        SwiftDriverRepo(),
+        SwiftCryptoRepo(),
+        SwiftCollectionsRepo(),
+        SPMRepo()
+    ]
+}
+
+struct SwiftRepo: Checkoutable {
+    let githubUrl = "https://github.com/apple/swift.git"
+
+    let revision: CheckoutRevision = .tag("swift-5.7-RELEASE")
+}
+
+struct LlvmProjectRepo: Checkoutable {
+    let githubUrl = "https://github.com/apple/llvm-project.git"
+}
+
+struct CMarkRepo: Checkoutable {
+    let githubUrl = "https://github.com/apple/swift-cmark.git"
+}
+
+struct YamsRepo: Checkoutable {
+    let githubUrl = "https://github.com/jpsim/Yams.git"
+}
+
+struct SwiftArgumentParserRepo: Checkoutable {
+    let githubUrl = "https://github.com/apple/swift-argument-parser.git"
+}
+
+struct SwiftSystemRepo: Checkoutable {
+    let githubUrl = "https://github.com/apple/swift-system.git"
+}
+
+struct SwiftLLBuildCoreRepo: Checkoutable {
+    let githubUrl = "https://github.com/apple/swift-llbuild.git"
+}
+
+struct SwiftDriverRepo: Checkoutable {
+    let githubUrl = "https://github.com/apple/swift-driver.git"
+}
+
+struct SwiftCryptoRepo: Checkoutable {
+    let githubUrl = "https://github.com/apple/swift-crypto.git"
+}
+
+struct SwiftCollectionsRepo: Checkoutable {
+    let githubUrl = "https://github.com/apple/swift-collections.git"
+}
+
+struct SPMRepo: Checkoutable {
+    let githubUrl = "https://github.com/apple/swift-package-manager.git"
+
+    let repoName: String = "swiftpm"
+}
+
+

--- a/Sources/SwiftBuilder/Steps/CheckoutStep.swift
+++ b/Sources/SwiftBuilder/Steps/CheckoutStep.swift
@@ -2,17 +2,30 @@ import Foundation
 import Logging
 import RegexBuilder
 
+enum CheckoutRevision {
+    case commit(String)
+    case tag(String)
+
+    /// default option, it will search hash in output of `utils/update-checkout`
+    case parseFromUpdateCheckoutOuput
+}
+
 protocol Checkoutable {
     var githubUrl: String { get }
 
-    var tag: String { get }
+    var revision: CheckoutRevision { get }
 
-    var folderName: String { get }
+    /// Will be used as folder name for checkout
+    var repoName: String { get }
 }
 
 extension Checkoutable {
-    var folderName: String {
+    var repoName: String {
         githubUrl.components(separatedBy: "/").last!.fileNameByRemovingExtension
+    }
+
+    var revision: CheckoutRevision {
+        .parseFromUpdateCheckoutOuput
     }
 }
 
@@ -24,7 +37,7 @@ actor CheckoutStep: BuildStep {
         self.checkoutables = checkoutables
         statuses = [:]
         for checkoutable in checkoutables {
-            statuses[checkoutable.folderName] = .starting
+            statuses[checkoutable.repoName] = .starting
         }
         self.sortedKeys = statuses.keys.sorted()
     }
@@ -32,6 +45,7 @@ actor CheckoutStep: BuildStep {
     func execute() async throws {
         // TODO: Implement actual checkout and check for existed repo
         // TODO: Implement reporing to terminal
+        fatalError("Implement actual checkout")
     }
 
     // MARK: Private
@@ -41,8 +55,10 @@ actor CheckoutStep: BuildStep {
     private var statuses: [String: Status]
     private let sortedKeys: [String]
 
+    private let defaultRevisionsMap = DefaultRevisionsMap()
+
     fileprivate func update(status: Status, of checkoutable: Checkoutable) {
-        statuses.increase(to: status, for: checkoutable.folderName)
+        statuses.increase(to: status, for: checkoutable.repoName)
     }
 }
 

--- a/Sources/SwiftBuilder/Steps/CheckoutStop.swift
+++ b/Sources/SwiftBuilder/Steps/CheckoutStop.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Logging
+import RegexBuilder
+
+protocol Checkoutable {
+    var githubUrl: String { get }
+
+    var tag: String { get }
+
+    var folderName: String { get }
+}
+
+extension Checkoutable {
+    var folderName: String {
+        githubUrl.components(separatedBy: "/").last!.fileNameByRemovingExtension
+    }
+}
+
+/// This step will checkout all needed repos for the build
+/// We will checkout few repos at the time, because this steps has fewer chances to fail
+actor CheckoutStep: BuildStep {
+
+    init(checkoutables: [Checkoutable]) {
+        self.checkoutables = checkoutables
+        statuses = [:]
+        for checkoutable in checkoutables {
+            statuses[checkoutable.folderName] = .starting
+        }
+        self.sortedKeys = statuses.keys.sorted()
+    }
+
+    func execute() async throws {
+        // TODO: Implement actual checkout and check for existed repo
+        // TODO: Implement reporing to terminal
+    }
+
+    // MARK: Private
+
+    private let checkoutables: [Checkoutable]
+
+    private var statuses: [String: Status]
+    private let sortedKeys: [String]
+
+    fileprivate func update(status: Status, of checkoutable: Checkoutable) {
+        statuses.increase(to: status, for: checkoutable.folderName)
+    }
+}
+
+private enum Status: Comparable {
+    case starting
+    case receivingObjects(Double)
+    case resolvingDeltas(Double)
+
+    static func < (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.starting, _):
+            return true
+        case (.receivingObjects, .starting):
+            return false
+        case let (.receivingObjects(l), .receivingObjects(r)):
+            return l < r
+        case (.receivingObjects, .resolvingDeltas):
+            return true
+        case let (.resolvingDeltas(l), .resolvingDeltas(r)):
+            return l < r
+        case (.resolvingDeltas,_):
+            return false
+        }
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.starting, .starting):
+            return true
+        case let (.receivingObjects(l), .receivingObjects(r)):
+            return abs(l - r) < 0.01
+        case let (.resolvingDeltas(l), .resolvingDeltas(r)):
+            return abs(l - r) < 0.01
+        default:
+            return false
+        }
+    }
+}
+
+private struct GitCheckoutStatusReceiver: LogHandler {
+
+    weak var checkoutStep: CheckoutStep?
+    let checkoutable: Checkoutable
+
+    init(checkoutable: Checkoutable, checkoutStep: CheckoutStep) {
+        self.checkoutable = checkoutable
+        self.checkoutStep = checkoutStep
+    }
+
+    subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+        get { self.metadata[key] }
+        set { self.metadata[key] = newValue }
+    }
+
+    var metadata: Logger.Metadata = [:]
+
+    var logLevel: Logger.Level = .info
+
+    func log(level: Logger.Level,
+             message: Logger.Message,
+             metadata: Logger.Metadata?,
+             source: String,
+             file: String,
+             function: String,
+             line: UInt) {
+        // We will try to parse few expected scenarios:
+        // Receiving objects:   3% (3656/121866)
+        // Receiving objects:   5% (6094/121866), 4.28 MiB | 8.41 MiB/s
+        // Receiving objects: 100% (121866/121866), 52.47 MiB | 6.15 MiB/s, done.
+        // Resolving deltas:   1% (635/63474)
+        // Resolving deltas: 100% (63474/63474), done.
+        let string = "\(message)"
+        let receivingMatch = string.firstMatch(of: receivingObjectsRegex)
+        let resolvingMatch = string.firstMatch(of: resolvingObjectsRegex)
+
+        let receivingStatus: Status? = receivingMatch.map { .receivingObjects($0.output.1) }
+        let resolvingStatus: Status? = resolvingMatch.map { .resolvingDeltas($0.output.1) }
+
+        let newStatus = resolvingStatus ?? receivingStatus
+
+        guard let newStatus else {
+            return
+        }
+
+        Task {
+            await checkoutStep?.update(status: newStatus, of: checkoutable)
+        }
+    }
+}
+
+private let receivingObjectsRegex = Regex {
+    "Receiving objects:"
+    OneOrMore(.whitespace)
+    Capture {
+        OneOrMore(.digit)
+    } transform: { str -> Double in
+        guard let digits = Double(str) else {
+            throw "Failed to convert \(str) to Double"
+        }
+        return digits/100.0 as Double
+    }
+    "%"
+    OneOrMore {
+        .any
+    }
+}
+
+private let resolvingObjectsRegex = Regex {
+    "Resolving deltas:"
+    OneOrMore(.whitespace)
+    Capture {
+        OneOrMore(.digit)
+    } transform: { str -> Double in
+        guard let digits = Double(str) else {
+            throw "Failed to convert \(str) to Double"
+        }
+        return digits/100.0 as Double
+    }
+    "%"
+    OneOrMore {
+        .any
+    }
+}

--- a/Sources/SwiftBuilder/SwiftBuildCommand.swift
+++ b/Sources/SwiftBuilder/SwiftBuildCommand.swift
@@ -1,0 +1,37 @@
+import ArgumentParser
+import Foundation
+import Logging
+import Shell
+
+protocol BuildStep {
+    func execute() async throws
+}
+
+@main
+final class SwiftBuildCommand: AsyncParsableCommand {
+
+    @Option(name: .long,
+            help: "Folder which will contain all checkouts, logs and final artefacts",
+            transform: { URL(fileURLWithPath: $0, isDirectory: true) })
+    var workingFolder: URL
+
+    func validate() throws {
+        // I knowthat this function throw error, if failed to create needed folder
+        try fileManager.createFolderIfNotExists(at: workingFolder)
+    }
+
+    func run() async throws {
+
+        // TODO: Create needed logger
+
+        let checkoutDestinationUrl = workingFolder.appendingPathComponent("spm", isDirectory: true)
+        try? fileManager.removeItem(at: checkoutDestinationUrl)
+        let gitRepoUrl = URL(string: "https://github.com/apple/servicetalk")!
+        let gitClone = GitClone(source: gitRepoUrl, destination: checkoutDestinationUrl)
+        try await gitClone.execute()
+    }
+
+    // MARK: Private
+
+    private var fileManager: FileManager { FileManager.default }
+}


### PR DESCRIPTION
Follow plan from [here](https://github.com/NikolayJuly/swift-toolchain-for-android-on-macos/issues/1)

This is first step - checkout all needed repos. 
Initial plan was to parse log from git, but it detects that there is no TTY and do not actually post status realtime. Found thread [here](https://developer.apple.com/forums/thread/688534). There are few other sggestions like [empty](https://empty.sourceforge.net), [script](https://www.ibm.com/docs/en/zos/2.4.0?topic=descriptions-script-makes-typescript-terminal-session) or [faketty](https://github.com/dtolnay/faketty). They didn't work ot require additional work to install/compile. Or all together.

So for we will show just list of checout statuses:
<img width="270" alt="Screenshot 2023-01-06 at 18 44 51" src="https://user-images.githubusercontent.com/699116/211079160-aeb33ed6-1a63-436a-9b08-e3d278e4435d.png">
