### PR TITLE
Swift 5.7 - Build test binary and execute on emulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ Package.resolved
 
 ## User settings
 xcuserdata/
-swift-builder.xcscheme
+.swiftpm/xcode/xcshareddata/xcschemes/swift-builder-Package.xcscheme
 
 ## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
 *.xcscmblueprint

--- a/.swiftpm/xcode/xcshareddata/xcschemes/SwiftBuilder.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/SwiftBuilder.xcscheme
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SwiftBuilder"
+               BuildableName = "SwiftBuilder"
+               BlueprintName = "SwiftBuilder"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Shell"
+               BuildableName = "Shell"
+               BlueprintName = "Shell"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "SwiftBuilder"
+            BuildableName = "SwiftBuilder"
+            BlueprintName = "SwiftBuilder"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "--working-folder"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/Users/nikolaydzhulay/ws/SwiftAndroid_working"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--android-sdk"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/Users/nikolaydzhulay/Library/Android/sdk"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--source-root"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/Users/nikolaydzhulay/ws/swift-toolchain-for-android-on-macos"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "CMAKE_PATH"
+            value = "/Users/nikolaydzhulay/Library/Android/sdk/cmake/3.22.1/bin"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "SwiftBuilder"
+            BuildableName = "SwiftBuilder"
+            BlueprintName = "SwiftBuilder"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/swift-on-android-test.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/swift-on-android-test.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "swift-on-android-test"
+               BuildableName = "swift-on-android-test"
+               BlueprintName = "swift-on-android-test"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "swift-on-android-test"
+            BuildableName = "swift-on-android-test"
+            BlueprintName = "swift-on-android-test"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "swift-on-android-test"
+            BuildableName = "swift-on-android-test"
+            BlueprintName = "swift-on-android-test"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.swift
+++ b/Package.swift
@@ -74,7 +74,6 @@ let package = Package(
                 "FoundationExtension",
                 "HostConfig",
                 "Shell",
-                .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "ConsoleKit", package: "console-kit"),
                 .product(name: "Logging", package: "swift-log"),
             ]),

--- a/Package.swift
+++ b/Package.swift
@@ -74,6 +74,7 @@ let package = Package(
                 "FoundationExtension",
                 "HostConfig",
                 "Shell",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "ConsoleKit", package: "console-kit"),
                 .product(name: "Logging", package: "swift-log"),
             ]),

--- a/Package.swift
+++ b/Package.swift
@@ -12,13 +12,16 @@ let package = Package(
             name: "SwiftBuilder",
             targets: [
                 "SwiftBuilder",
-                "Shell",
             ]),
         .executable(
             name: "swiftc-android",
             targets: [
-                "Shell",
                 "SwiftcAndroid",
+            ]),
+        .executable(
+            name: "swift-on-android-test",
+            targets: [
+                "SampleAndroidBinary"
             ]),
     ],
     dependencies: [
@@ -41,6 +44,7 @@ let package = Package(
                 ]),
         .target(name: "HostConfig",
                 dependencies: ["FoundationExtension"]),
+        .executableTarget(name: "SampleAndroidBinary"),
         .target(
             name: "Shell",
             dependencies: [

--- a/README.md
+++ b/README.md
@@ -7,7 +7,28 @@ Swift toolchain for android on macos
 - Recent xcode vetsion installed on mac
 - Install NDK and CMake. [Instructions](https://developer.android.com/studio/projects/install-ndk)
 
-## Execute
+## Use toolchain
+
+Here are steps to compile package
+
+- `$ export PATH="<toolchain_path>/usr/bin:$PATH"`
+- `$ export SWIFT_EXEC_MANIFEST=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc`
+- `export SWIFT_EXEC=<toolchain_path>/usr/bin/swiftc-android`  and `swiftc-android` should be executable
+- `cd <package_path>`
+-
+ ```
+ swift build --triple aarch64-unknown-linux-android \
+    --emit-swift-module-separately \
+    --sdk <toolchain_path> \
+    --toolchain <toolchain_path>/bin \
+    -Xswiftc -emit-library \
+    -Xswiftc -emit-module \
+    -Xcc -I-I$USER/Library/Android/sdk/ndk/25.1.8937393/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include \
+    -Xcc -I-I$USER/Library/Android/sdk/ndk/25.1.8937393/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/aarch64-linux-android \
+    -v
+```
+
+## Build toolchain
 ```
 $ swift run SwiftBuilder \
   --working-folder <WORKING_FOLDER> \
@@ -34,3 +55,6 @@ If you want start from scratch - just delete file from working folder. Alternati
 2. Follow steps [here](./Sources/SwiftBuilder/Repos/HowToGetCommitHashes.md) to update default checkout hashes
 3. Consider changing `CMAKE_OSX_DEPLOYMENT_TARGET`
 4. Execute and fix issue by issue...
+
+
+

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Here are steps to compile package
  swift build --triple aarch64-unknown-linux-android \
     --emit-swift-module-separately \
     --sdk <toolchain_path> \
-    --toolchain <toolchain_path>/bin \
+    --toolchain <toolchain_path>/usr/bin \
     -Xswiftc -emit-library \
     -Xswiftc -emit-module \
     -Xcc -I/Users/$USER/Library/Android/sdk/ndk/25.1.8937393/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include \

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Here are steps to compile package
     --toolchain <toolchain_path>/bin \
     -Xswiftc -emit-library \
     -Xswiftc -emit-module \
-    -Xcc -I-I$USER/Library/Android/sdk/ndk/25.1.8937393/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include \
-    -Xcc -I-I$USER/Library/Android/sdk/ndk/25.1.8937393/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/aarch64-linux-android \
+    -Xcc -I/Users/$USER/Library/Android/sdk/ndk/25.1.8937393/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include \
+    -Xcc -I/Users/$USER/Library/Android/sdk/ndk/25.1.8937393/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/aarch64-linux-android \
     -v
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Here are steps to compile package
 ```
 $ swift run SwiftBuilder \
   --working-folder <WORKING_FOLDER> \
-  --android-sdk <PATH_TO_ANDROID_SDK>
+  --android-sdk <PATH_TO_ANDROID_SDK> \
   --source-root "$PWD"
 ```
 For example, values might be:

--- a/Sources/HostConfig/AndroidSDK.swift
+++ b/Sources/HostConfig/AndroidSDK.swift
@@ -3,11 +3,22 @@ import FoundationExtension
 
 public struct AndroidSDK {
 
+    public let sdkRootUrl: URL
+
     public let ndk: NDK
     public let cmake: CMake
 
     /// On init, AndroidSDK will search for valid cmake and ndk
     public init(path: String) throws {
+
+        self.sdkRootUrl = URL(filePath: path, directoryHint: .isDirectory)
+
+        let fileManager = FileManager.default
+
+        guard fileManager.folderExists(at: sdkRootUrl) else {
+            throw SimpleError("Android SDK folder doesn't exist at \(path)")
+        }
+
         let ndksFolderPath = path + "/ndk"
 
         self.ndk = try Self.create(itemsFolderPath: ndksFolderPath, name: "ndk", create: NDK.init)

--- a/Sources/HostConfig/NDK.swift
+++ b/Sources/HostConfig/NDK.swift
@@ -15,6 +15,22 @@ public struct NDK {
 
     public let toolchain: URL
 
+    public var toolchainPath: String {
+        toolchain.path()
+    }
+
+    public var sysrootLib: URL {
+        toolchain.appending(path: "/sysroot/usr/lib", directoryHint: .isDirectory)
+    }
+
+    public var sysrootLibPath: String {
+        sysrootLib.path()
+    }
+
+    public var sysrootIncludePath: String {
+        toolchainPath + "/sysroot/usr/include"
+    }
+
     public init(folderPath: String) throws {
         let url = URL(filePath: folderPath, directoryHint: .isDirectory)
         try self.init(folderUrl: url)
@@ -28,7 +44,7 @@ public struct NDK {
         let version = try Version(ndkVersionString)
 
         guard "\(version.major)" == Self.version else {
-            throw SimpleError("Currently we workign only with NDK v\(version)")
+            throw SimpleError("Currently we workign only with NDK v\(version.versionString)")
         }
 
         self.toolchain = folderUrl.appending(path: "/toolchains/llvm/prebuilt/darwin-x86_64", directoryHint: .isDirectory)

--- a/Sources/HostConfig/Version.swift
+++ b/Sources/HostConfig/Version.swift
@@ -2,7 +2,7 @@ import Foundation
 import FoundationExtension
 
 /// Version, were all elements are integers, might contain build, if it is integer
-struct Version: Comparable, Equatable {
+struct Version: Comparable, Equatable, CustomStringConvertible {
 
     let major: Int
     let minor: Int
@@ -42,6 +42,10 @@ struct Version: Comparable, Equatable {
             return lhsNumbers[i] < rhsNumbers[i]
         }
         return true
+    }
+
+    var description: String {
+        versionString
     }
 
     // MARK: Private

--- a/Sources/SampleAndroidBinary/main.swift
+++ b/Sources/SampleAndroidBinary/main.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Nikolay Dzhulay on 29/07/2023.
+//
+
+import Foundation

--- a/Sources/SampleAndroidBinary/main.swift
+++ b/Sources/SampleAndroidBinary/main.swift
@@ -1,8 +1,3 @@
-//
-//  File.swift
-//  
-//
-//  Created by Nikolay Dzhulay on 29/07/2023.
-//
-
 import Foundation
+
+print("Hello world")

--- a/Sources/Shell/ExecuteBinaryCommand.swift
+++ b/Sources/Shell/ExecuteBinaryCommand.swift
@@ -28,9 +28,11 @@ public final class ExecuteBinaryCommand {
     }
 
     /// If no output - empty srting will be returned
+    /// - parameter didStartMarker: resume will be called after process did start, so we know that we can call ``terminate``
     @discardableResult
-    public func execute() async throws -> String {
+    public func execute(didStartMarker: CheckedContinuation<Void, Never>? = nil) async throws -> String {
         let task = Process()
+        self.task = task
 
         let pipe = Pipe()
         let errorPipe = Pipe()
@@ -50,11 +52,11 @@ public final class ExecuteBinaryCommand {
         task.executableURL = binary
         task.standardInput = nil
 
-        if let currentDirectoryURL = currentDirectoryURL {
+        if let currentDirectoryURL {
             task.currentDirectoryURL = currentDirectoryURL
         }
 
-        if let environment = environment {
+        if let environment {
             task.environment = environment
         }
 
@@ -119,6 +121,7 @@ public final class ExecuteBinaryCommand {
             } catch let exc {
                 logger.error("Failed to run task with error - \(exc)")
             }
+            didStartMarker?.resume()
         }
 
         lock.withLock {
@@ -150,6 +153,10 @@ public final class ExecuteBinaryCommand {
         return output
     }
 
+    public func terminate() {
+        task?.terminate()
+    }
+
     // MARK: Private
 
     private let binary: URL
@@ -163,4 +170,6 @@ public final class ExecuteBinaryCommand {
 
     private var stdOut = [String]()
     private var errorOut = [String]()
+
+    private var task: Process?
 }

--- a/Sources/Shell/ExecuteBinaryCommand.swift
+++ b/Sources/Shell/ExecuteBinaryCommand.swift
@@ -30,7 +30,7 @@ public final class ExecuteBinaryCommand {
     /// If no output - empty srting will be returned
     /// - parameter didStartMarker: resume will be called after process did start, so we know that we can call ``terminate``
     @discardableResult
-    public func execute(didStartMarker: CheckedContinuation<Void, Never>? = nil) async throws -> String {
+    public func execute() async throws -> String {
         let task = Process()
         self.task = task
 
@@ -121,7 +121,6 @@ public final class ExecuteBinaryCommand {
             } catch let exc {
                 logger.error("Failed to run task with error - \(exc)")
             }
-            didStartMarker?.resume()
         }
 
         lock.withLock {

--- a/Sources/Shell/ShellCommand.swift
+++ b/Sources/Shell/ShellCommand.swift
@@ -34,7 +34,8 @@ public final class ShellCommand {
     @discardableResult
     public func execute() async throws -> String {
         let commandString = command.joined(separator: " ")
-        let command = ExecuteBinaryCommand(URL(fileURLWithPath: "/bin/zsh"),
+        let zShell = URL(filePath: "/bin/zsh", directoryHint: .notDirectory)
+        let command = ExecuteBinaryCommand(zShell,
                                            ["-c", "-l"] + [commandString],
                                            currentDirectoryURL: currentDirectoryURL,
                                            environment: environment,

--- a/Sources/SwiftBuilder/AndroidEmulator/AndroidADB.swift
+++ b/Sources/SwiftBuilder/AndroidEmulator/AndroidADB.swift
@@ -4,6 +4,10 @@ import HostConfig
 import Logging
 import Shell
 
+extension String {
+    static let emulatorName = "emulator-5566"
+}
+
 final class AndroidADB {
     init(androidSdk: AndroidSDK,
          logger: Logger) async throws {
@@ -20,7 +24,7 @@ final class AndroidADB {
 
     func deleteBinPath() async throws {
         let coomand = ExecuteBinaryCommand(adbBinaryUrl,
-                                           "-s ", "emulator-5566",
+                                           "-s", String.emulatorName,
                                            "shell",
                                            "rm", "-f", emulatorBinPath,
                                            logger: logger)
@@ -36,7 +40,7 @@ final class AndroidADB {
         let resFilename = filename ?? source.lastPathComponent
 
         let coomand = ExecuteBinaryCommand(adbBinaryUrl,
-                                           "-s ", "emulator-5566",
+                                           "-s", String.emulatorName,
                                            "push", source.path(), emulatorBinPath + resFilename,
                                            logger: logger)
         try await coomand.execute()
@@ -44,11 +48,24 @@ final class AndroidADB {
 
     func run(_ binaryName: String) async throws -> String {
         let coomand = ExecuteBinaryCommand(adbBinaryUrl,
-                                           "-s ", "emulator-5566",
+                                           "-s", String.emulatorName,
                                            "shell", "LD_LIBRARY_PATH=\(emulatorBinPath)",
                                            "/data/bin/\(binaryName)",
                                            logger: logger)
         return try await coomand.execute()
+    }
+
+    func listConnectedDevices() async throws -> [String] {
+        let coomand = ExecuteBinaryCommand(adbBinaryUrl, "devices", logger: logger)
+        let output = try await coomand.execute()
+        let lines = output.components(separatedBy: "\n")
+        let devices = lines.compactMap { line -> String? in
+            guard line.isOnlineDevice else {
+                return nil
+            }
+            return line.deviceName
+        }
+        return devices
     }
 
     // MARK: Private
@@ -59,4 +76,20 @@ final class AndroidADB {
     private let adbBinaryUrl: URL
 
     private let emulatorBinPath: String = "/data/bin/"
+}
+
+private extension String {
+    var isOnlineDevice: Bool {
+        let components = self.components(separatedBy: "\t")
+        guard components.count == 2 else {
+            return false
+        }
+
+        // looks like this means attached. Also can be "offline"
+        return components[1] == "device"
+    }
+
+    var deviceName: String? {
+        components(separatedBy: "\t").first
+    }
 }

--- a/Sources/SwiftBuilder/AndroidEmulator/AndroidADB.swift
+++ b/Sources/SwiftBuilder/AndroidEmulator/AndroidADB.swift
@@ -26,7 +26,7 @@ final class AndroidADB {
         let coomand = ExecuteBinaryCommand(adbBinaryUrl,
                                            "-s", String.emulatorName,
                                            "shell",
-                                           "rm", "-f", emulatorBinPath,
+                                           "rm", "-fr", emulatorBinPath,
                                            logger: logger)
         try await coomand.execute()
     }

--- a/Sources/SwiftBuilder/AndroidEmulator/AndroidADB.swift
+++ b/Sources/SwiftBuilder/AndroidEmulator/AndroidADB.swift
@@ -1,0 +1,62 @@
+import Foundation
+import FoundationExtension
+import HostConfig
+import Logging
+import Shell
+
+final class AndroidADB {
+    init(androidSdk: AndroidSDK,
+         logger: Logger) async throws {
+        self.androidSdk = androidSdk
+        self.logger = logger
+
+        self.adbBinaryUrl = androidSdk.sdkRootUrl.appending(path: "platform-tools/adb", directoryHint: .notDirectory)
+
+        // Lets make sure it is running
+        let command = ExecuteBinaryCommand(adbBinaryUrl, "start-server",
+                                           logger: logger)
+        try await command.execute()
+    }
+
+    func deleteBinPath() async throws {
+        let coomand = ExecuteBinaryCommand(adbBinaryUrl,
+                                           "-s ", "emulator-5566",
+                                           "shell",
+                                           "rm", "-f", emulatorBinPath,
+                                           logger: logger)
+        try await coomand.execute()
+    }
+    
+    /// Copy file to emulator. File will be copyed to destination folder and might be renamed if needed. Destination folder doesn't have any structure
+    /// - Parameters:
+    ///   - source: file url
+    ///   - filename: name of destination file, pass nil, if we need to keep the same name
+    func copy(_ source: URL, filename: String? = nil) async throws {
+
+        let resFilename = filename ?? source.lastPathComponent
+
+        let coomand = ExecuteBinaryCommand(adbBinaryUrl,
+                                           "-s ", "emulator-5566",
+                                           "push", source.path(), emulatorBinPath + resFilename,
+                                           logger: logger)
+        try await coomand.execute()
+    }
+
+    func run(_ binaryName: String) async throws -> String {
+        let coomand = ExecuteBinaryCommand(adbBinaryUrl,
+                                           "-s ", "emulator-5566",
+                                           "shell", "LD_LIBRARY_PATH=\(emulatorBinPath)",
+                                           "/data/bin/\(binaryName)",
+                                           logger: logger)
+        return try await coomand.execute()
+    }
+
+    // MARK: Private
+
+    private let androidSdk: AndroidSDK
+    private let logger: Logger
+
+    private let adbBinaryUrl: URL
+
+    private let emulatorBinPath: String = "/data/bin/"
+}

--- a/Sources/SwiftBuilder/AndroidEmulator/AndroidEmulator.swift
+++ b/Sources/SwiftBuilder/AndroidEmulator/AndroidEmulator.swift
@@ -34,14 +34,14 @@ actor AndroidEmulator {
         }
 
         let runEmulator = ExecuteBinaryCommand(emulatorBinaryUrl,
-                                                 "-avd", "Pixel_6_API_33",
-                                                 "-netdelay", "none",
-                                                 "-netspeed", "full",
-                                                 "-no-audio",
-                                                 "-no-window",
-                                                 "-id", "swift_test",
-                                                 "-port", .emulatorPrt,
-                                                 logger: logger)
+                                               "-avd", avdName,
+                                               "-netdelay", "none",
+                                               "-netspeed", "full",
+                                               "-no-audio",
+                                               "-no-window",
+                                               "-id", "swift_test",
+                                               "-port", .emulatorPrt,
+                                               logger: logger)
 
         await withCheckedContinuation { continuation in
             Task {

--- a/Sources/SwiftBuilder/AndroidEmulator/AndroidEmulator.swift
+++ b/Sources/SwiftBuilder/AndroidEmulator/AndroidEmulator.swift
@@ -1,0 +1,105 @@
+import Foundation
+import FoundationExtension
+import HostConfig
+import Logging
+import Shell
+
+extension String {
+    static let emulatorPrt: String = "5566"
+}
+
+actor AndroidEmulator {
+    // TODO: Later we can add support for [avdmanager](https://developer.android.com/tools/avdmanager), but it require java runtime
+    /// On init, we will try to find expected emulator - Pixel 6
+    init(androidSdk: AndroidSDK,
+         logger: Logger) async throws {
+        self.androidSdk = androidSdk
+        self.logger = logger
+
+        let emulatorBinaryUrl = androidSdk.sdkRootUrl.appending(path: "emulator/emulator", directoryHint: .notDirectory)
+        let listEmulators = ExecuteBinaryCommand(emulatorBinaryUrl, "-list-avds", logger: logger)
+        let ourtput = try await listEmulators.execute()
+        let emulatorsList = ourtput.components(separatedBy: "\n")
+        guard let pixel6Avd = emulatorsList.first(where: { $0.hasPrefix("Pixel_6") }) else {
+            throw SimpleError("Failed to find AVD with \"Pixel_6\" prefix")
+        }
+
+        self.avdName = pixel6Avd
+        self.emulatorBinaryUrl = emulatorBinaryUrl
+    }
+
+    func start() async throws {
+        guard case .notRunning = state else {
+            throw SimpleError("We can't start in current state - \(state)")
+        }
+
+        let runEmulator = ExecuteBinaryCommand(emulatorBinaryUrl,
+                                                 "-avd", "Pixel_6_API_33",
+                                                 "-netdelay", "none",
+                                                 "-netspeed", "full",
+                                                 "-no-audio",
+                                                 "-no-window",
+                                                 "-id", "swift_test",
+                                                 "-port", .emulatorPrt,
+                                                 logger: logger)
+
+        await withCheckedContinuation { continuation in
+            Task {
+                do {
+                    try await runEmulator.execute(didStartMarker: continuation)
+                } catch {
+                    switch state {
+                    case let .stopping(continuation):
+                        logger.error("Did stop emulator")
+                        continuation.resume()
+                        break
+                    case .running, .notRunning:
+                        logger.error("Did catch exception during execution - \(error)")
+                    }
+                }
+
+                self.state = .notRunning
+            }
+        }
+
+        self.state = .running(runEmulator)
+    }
+
+    func stop() async throws {
+        guard case let .running(command) = state else {
+            throw SimpleError("We can't stop in current state - \(state)")
+        }
+
+        await withCheckedContinuation { continuation in
+            self.state = .stopping(continuation)
+            command.terminate()
+        }
+    }
+
+    // MARK: Private
+
+    private enum State: CustomStringConvertible {
+        case notRunning
+        case running(ExecuteBinaryCommand)
+        case stopping(CheckedContinuation<Void, Never>)
+
+        var description: String {
+            switch self {
+            case .notRunning:
+                return "State.notRunning"
+            case .running:
+                return "State.running"
+            case .stopping:
+                return "State.stopping"
+            }
+        }
+    }
+
+    private let androidSdk: AndroidSDK
+    private let logger: Logger
+
+    private let avdName: String
+    private let emulatorBinaryUrl: URL
+
+    private var state: State = .notRunning
+}

--- a/Sources/SwiftBuilder/AndroidEmulator/RunBinaryInEmulatorStep.swift
+++ b/Sources/SwiftBuilder/AndroidEmulator/RunBinaryInEmulatorStep.swift
@@ -25,6 +25,9 @@ final class RunBinaryInEmulatorStep: BuildStep {
         do {
             let adb = try await AndroidADB(androidSdk: config.androidSdk, logger: logger)
             try await waitTillDeviceAttached(String.emulatorName, adb: adb, logger: logger)
+
+            try await adb.deleteBinPath()
+
             try await copyAllNeededLibs(config, adb: adb, logger: logger)
 
             try await adb.copy(compiledTestBinary)
@@ -34,6 +37,8 @@ final class RunBinaryInEmulatorStep: BuildStep {
             guard testBinaryOutput == "Hello world" else {
                 throw SimpleError("Unexpected outup of test binary - \(testBinaryOutput). Expects \"Hello world\"")
             }
+
+            logger.info("We did run test in emulator and got expected \"Hello world\"")
         } catch {
             try? await androidEmulator.stop()
             throw error

--- a/Sources/SwiftBuilder/AndroidEmulator/RunBinaryInEmulatorStep.swift
+++ b/Sources/SwiftBuilder/AndroidEmulator/RunBinaryInEmulatorStep.swift
@@ -1,3 +1,4 @@
+import AndroidConfig
 import Foundation
 import HostConfig
 import Logging
@@ -15,7 +16,65 @@ final class RunBinaryInEmulatorStep: BuildStep {
         let androidEmulator = try await AndroidEmulator(androidSdk: config.androidSdk,
                                                         logger: logger)
         try await androidEmulator.start()
+
+        do {
+            let adb = try await AndroidADB(androidSdk: config.androidSdk, logger: logger)
+            try await copyAllNeededLibs(config, adb: adb, logger: logger)
+
+        } catch {
+            try? await androidEmulator.stop()
+            throw error
+        }
+
         try await androidEmulator.stop()
+
         progressReporter.update(state: .done)
+    }
+
+    // MARK: Private
+
+    // TODO: We need to find the way not to depend on .so.65 files, and only depend on .so, then we can simplify it
+    // TODO: Ideally we can actually make these map automatically.
+    //       Use `objdump -x  <oaht_to_binary> | grep ‘R.*PATH’` - it will prent all needed files, and we can search thim in toolchain.
+    //       And then check dependency of a dependency and repeat copy process.
+    private let toolchainFileMap: [String: [String?]] = [
+        "libFoundation.so": [nil],
+        "libswiftGlibc.so": [nil],
+        "libswiftDispatch.so": [nil],
+        "libdispatch.so": [nil],
+        "libBlocksRuntime.so": [nil],
+        "libswift_Concurrency.so": [nil],
+        "libswiftCore.so": [nil],
+        "libswiftSwiftOnoneSupport.so": [nil],
+        "libicutuswift.so": [nil, "libicutuswift.so.65"],
+        "libicuucswift.so": [nil, "libicuucswift.so.65"],
+        "libicudataswift.so": [nil, "libicudataswift.so.65"],
+        "libicui18nswift.so": [nil, "libicui18nswift.so.65"],
+    ]
+
+    private let ndkFiles = ["libc++_shared.so"]
+
+    private func copyAllNeededLibs(_ config: BuildConfig, adb: AndroidADB, logger: Logger) async throws {
+
+        let arch = AndroidArchs.arm64
+
+        for key in toolchainFileMap.keys {
+            let toolchainLib = key
+            let destinations = toolchainFileMap[key]!
+
+            let sourceUrl = config.toolchainAndroidsLib(for: arch).appending(path: toolchainLib, directoryHint: .notDirectory)
+
+            for destination in destinations {
+                try await adb.copy(sourceUrl, filename: destination)
+            }
+        }
+
+        for ndkFile in ndkFiles {
+            let sourceUrl = config.ndk.sysrootLib.appending(path: "\(arch.ndkLibArchName)/\(ndkFile)", directoryHint: .notDirectory)
+            try await adb.copy(sourceUrl)
+        }
+    }
+
+    private func compileSampleAndroidBinary() {
     }
 }

--- a/Sources/SwiftBuilder/AndroidEmulator/RunBinaryInEmulatorStep.swift
+++ b/Sources/SwiftBuilder/AndroidEmulator/RunBinaryInEmulatorStep.swift
@@ -1,0 +1,21 @@
+import Foundation
+import HostConfig
+import Logging
+
+final class RunBinaryInEmulatorStep: BuildStep {
+
+    init() { }
+
+    // MARK: BuildStep
+
+    var stepName: String { "run-sample-binary-in-emulator" }
+
+    func execute(_ config: BuildConfig, logger: Logger) async throws {
+        let progressReporter = StepProgressReporter(step: "Run in emulator", initialState: .make)
+        let androidEmulator = try await AndroidEmulator(androidSdk: config.androidSdk,
+                                                        logger: logger)
+        try await androidEmulator.start()
+        try await androidEmulator.stop()
+        progressReporter.update(state: .done)
+    }
+}

--- a/Sources/SwiftBuilder/Builds/ICUBuild.swift
+++ b/Sources/SwiftBuilder/Builds/ICUBuild.swift
@@ -73,7 +73,6 @@ private final class BuildIcuStep: BuildStep {
         let arguments: [String] = [
             "--prefix=\(installFolderUrl.path)",
             "--host=\(icu.arch.ndkLibArchName)",
-            "--with-library-suffix=swift",
             "--enable-static=no",
             "--enable-shared",
             "--enable-extras=no",

--- a/Sources/SwiftBuilder/Builds/LibCurlBuild.swift
+++ b/Sources/SwiftBuilder/Builds/LibCurlBuild.swift
@@ -85,7 +85,7 @@ private final class BuildLibCurlStep: BuildStep {
         let openSslInstallUrl = config.installLocation(for: openSSL)
 
         let configureArguments: [String] = [
-            "--with-zlib=\(config.ndkToolchain)/sysroot/usr",
+            "--with-zlib=\(config.ndk.toolchainPath)/sysroot/usr",
             "--prefix=\(installFolderUrl.path)",
             "--enable-shared",
             "--disable-static",

--- a/Sources/SwiftBuilder/Builds/LibDispatchBuild.swift
+++ b/Sources/SwiftBuilder/Builds/LibDispatchBuild.swift
@@ -18,15 +18,15 @@ struct LibDispatchBuild: BuildItemForAndroidArch, NinjaBuildableItem {
     func cmakeCacheEntries(config: BuildConfig) -> [String] {
         let cmakeSwiftFlags = [
             "-resource-dir \(config.buildLocation(for: stdlib).path)/lib/swift",
-            "-Xcc --sysroot=\(config.ndkToolchain)/sysroot",
+            "-Xcc --sysroot=\(config.ndk.toolchainPath)/sysroot",
 
             // I got error, that can't find start stop files - https://stackoverflow.com/questions/69795531/after-ndk22-upgrade-the-build-fails-with-cannot-open-crtbegin-so-o-crtend-so
             // More detailed explanation - https://github.com/NikolayJuly/swift-toolchain-for-android-on-macos/issues/1#issuecomment-1426774354
             "-Xclang-linker -nostartfiles",
 
-            "-Xclang-linker --sysroot=\(config.ndkToolchain)/sysroot/usr/lib/\(arch.ndkLibArchName)/\(config.androidApiLevel)",
-            "-Xclang-linker --gcc-toolchain=\(config.ndkToolchain)",
-            "-tools-directory \(config.ndkToolchain)/bin",
+            "-Xclang-linker --sysroot=\(config.ndk.sysrootLibPath)/\(arch.ndkLibArchName)/\(config.androidApiLevel)",
+            "-Xclang-linker --gcc-toolchain=\(config.ndk.toolchainPath)",
+            "-tools-directory \(config.ndk.toolchainPath)/bin",
 
             //"-Xclang-linker -v",
             //"-v",

--- a/Sources/SwiftBuilder/Builds/LibFoundationBuild.swift
+++ b/Sources/SwiftBuilder/Builds/LibFoundationBuild.swift
@@ -24,15 +24,15 @@ struct LibFoundationBuild: BuildItemForAndroidArch, NinjaBuildableItem {
     func cmakeCacheEntries(config: BuildConfig) -> [String] {
         let cmakeSwiftFlags = [
             "-resource-dir \(config.buildLocation(for: stdlib).path)/lib/swift",
-            "-Xcc --sysroot=\(config.ndkToolchain)/sysroot",
+            "-Xcc --sysroot=\(config.ndk.toolchainPath)/sysroot",
 
             // I got error, that can't find start stop files - https://stackoverflow.com/questions/69795531/after-ndk22-upgrade-the-build-fails-with-cannot-open-crtbegin-so-o-crtend-so
             // More detailed explanation - https://github.com/NikolayJuly/swift-toolchain-for-android-on-macos/issues/1#issuecomment-1426774354
             "-Xclang-linker -nostartfiles",
 
-            "-Xclang-linker --sysroot=\(config.ndkToolchain)/sysroot/usr/lib/\(arch.ndkLibArchName)/\(config.androidApiLevel)",
-            "-Xclang-linker --gcc-toolchain=\(config.ndkToolchain)",
-            "-tools-directory \(config.ndkToolchain)/bin",
+            "-Xclang-linker --sysroot=\(config.ndk.sysrootLibPath)/\(arch.ndkLibArchName)/\(config.androidApiLevel)",
+            "-Xclang-linker --gcc-toolchain=\(config.ndk.toolchainPath)",
+            "-tools-directory \(config.ndk.toolchainPath)/bin",
 
             //"-Xclang-linker -v",
             //"-v",

--- a/Sources/SwiftBuilder/Builds/LibFoundationBuild.swift
+++ b/Sources/SwiftBuilder/Builds/LibFoundationBuild.swift
@@ -81,8 +81,8 @@ struct LibFoundationBuild: BuildItemForAndroidArch, NinjaBuildableItem {
             // ICU
             "ICU_LIBRARY=\(icuInstallPath)/lib",
             "ICU_INCLUDE_DIR=\(icuInstallPath)/include",
-            "ICU_I18N_LIBRARY_RELEASE=\(icuInstallPath)/lib/libicui18nswift.so",
-            "ICU_UC_LIBRARY_RELEASE=\(icuInstallPath)/lib/libicuucswift.so",
+            "ICU_I18N_LIBRARY_RELEASE=\(icuInstallPath)/lib/libicui18n.so",
+            "ICU_UC_LIBRARY_RELEASE=\(icuInstallPath)/lib/libicuuc.so",
 
             // XML
             "LIBXML2_INCLUDE_DIR=\(libXmlInstallPath)/include/libxml2",

--- a/Sources/SwiftBuilder/Builds/LibOpenSSLBuild.swift
+++ b/Sources/SwiftBuilder/Builds/LibOpenSSLBuild.swift
@@ -63,7 +63,7 @@ private final class BuildLibOpenSSLStep: BuildStep {
 
         let exports: [String] = [
             "ANDROID_NDK=\(config.ndkPath)",
-            "PATH=\(config.ndkToolchain)/bin:$PATH"
+            "PATH=\(config.ndk.toolchainPath)/bin:$PATH"
         ]
 
         let configureArguments: [String] = [

--- a/Sources/SwiftBuilder/Builds/LibXML2Build.swift
+++ b/Sources/SwiftBuilder/Builds/LibXML2Build.swift
@@ -82,8 +82,8 @@ private final class BuildLibXml2Step: BuildStep {
 
         // Actual list of arguments can be found in `swift-corelibs-foundation/build-android`
         let configureArguments: [String] = [
-            "--with-sysroot=\(config.ndkToolchain)/sysroot",
-            "--with-zlib=\(config.ndkToolchain)/sysroot/usr",
+            "--with-sysroot=\(config.ndk.toolchainPath)/sysroot",
+            "--with-zlib=\(config.ndk.toolchainPath)/sysroot/usr",
             "--prefix=\(installFolderUrl.path)",
             "--without-lzma",
             "--disable-static",

--- a/Sources/SwiftBuilder/Builds/StdLibBuild.swift
+++ b/Sources/SwiftBuilder/Builds/StdLibBuild.swift
@@ -33,7 +33,7 @@ struct StdLibBuild: BuildItemForAndroidArch, NinjaBuildableItem {
             "SWIFT_HOST_VARIANT_SDK=ANDROID",
             "SWIFT_HOST_VARIANT_ARCH=" + arch.swiftArch,
             "SWIFT_SDKS=\"ANDROID\"",
-            "SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS='-sdk;\(config.ndkToolchain)/sysroot'", // also might add `;-v` for verbose
+            "SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS='-sdk;\(config.ndk.toolchainPath)/sysroot'", // also might add `;-v` for verbose
 
             "SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=TRUE",
 

--- a/Sources/SwiftBuilder/Steps/MakeStep.swift
+++ b/Sources/SwiftBuilder/Steps/MakeStep.swift
@@ -18,7 +18,7 @@ final class MakeStep: BuildStep {
         let buildFolderUrl = config.buildLocation(for: buildableItem)
         let command = ShellCommand(["make"] + makeArgs,
                                    currentDirectoryURL: buildFolderUrl,
-                                   environment: ["PATH": "\(config.ndkToolchain)/bin"],
+                                   environment: ["PATH": "\(config.ndk.toolchainPath)/bin"],
                                    logger: logger)
         try await command.execute()
 

--- a/Sources/SwiftBuilder/SwiftBuildCommand.swift
+++ b/Sources/SwiftBuilder/SwiftBuildCommand.swift
@@ -33,14 +33,14 @@ struct BuildConfig {
 
     // MARK: NDK
 
+    var ndk: NDK {
+        androidSdk.ndk
+    }
+
     var ndkPath: String { androidSdk.ndk.folderUrl.path() }
 
     var ndkGccVersion: String { NDK.gccVersion }
     var ndkClangVersion: String { NDK.clangVersion }
-
-    var ndkToolchain: String {
-        androidSdk.ndk.toolchain.path()
-    }
 
     // MARK: macOS
 

--- a/Sources/SwiftBuilder/SwiftBuildCommand.swift
+++ b/Sources/SwiftBuilder/SwiftBuildCommand.swift
@@ -136,7 +136,12 @@ final class SwiftBuildCommand: AsyncParsableCommand {
 
             stepLogger.info("Executing step \(type(of: step))")
 
-            try await step.execute(buildConfig, logger: stepLogger)
+            do {
+                try await step.execute(buildConfig, logger: stepLogger)
+            } catch {
+                stepLogger.error("Caught error - \(error)")
+                throw error
+            }
 
             if buildProgress.completedSteps.contains(step.stepName) == false {
                 buildProgress = buildProgress.updated(byAdding: step.stepName)
@@ -158,6 +163,8 @@ final class SwiftBuildCommand: AsyncParsableCommand {
 
         let createToolchainStep = CreateToolchainStep(components: ToolchaninComponents.allComponents)
 
-        return [checkoutStep] + buildSteps + [createToolchainStep]
+        let runInEmulator = RunBinaryInEmulatorStep()
+
+        return [checkoutStep] + buildSteps + [createToolchainStep, runInEmulator]
     }()
 }

--- a/Sources/SwiftBuilder/SwiftBuildCommand.swift
+++ b/Sources/SwiftBuilder/SwiftBuildCommand.swift
@@ -125,14 +125,7 @@ final class SwiftBuildCommand: AsyncParsableCommand {
                 continue
             }
 
-            let stepNumberString = String(format: "%03d", i+1)
-            let logFileName = "Step-\(stepNumberString)-\(step.stepName).log"
-            let logFileURL = buildConfig.logsFolder.appendingPathComponent(logFileName, isDirectory: false)
-            try? fileManager.removeItem(at: logFileURL)
-            let fileLogger = try FileLogging(to: logFileURL)
-            let stepLogger = Logger(label: step.stepName) { label in
-                fileLogger.handler(label: label)
-            }
+            let stepLogger = try createStepLogger(index: i, buildConfig: buildConfig, step: step)
 
             stepLogger.info("Executing step \(type(of: step))")
 
@@ -167,4 +160,17 @@ final class SwiftBuildCommand: AsyncParsableCommand {
 
         return [checkoutStep] + buildSteps + [createToolchainStep, runInEmulator]
     }()
+
+    private func createStepLogger(index: Int, buildConfig: BuildConfig, step: BuildStep) throws -> Logger {
+        let stepNumberString = String(format: "%03d", index+1)
+        let logFileName = "Step-\(stepNumberString)-\(step.stepName).log"
+        let logFileURL = buildConfig.logsFolder.appendingPathComponent(logFileName, isDirectory: false)
+        try? fileManager.removeItem(at: logFileURL)
+        let fileLogger = try FileLogging(to: logFileURL)
+        let stepLogger = Logger(label: step.stepName) { label in
+            fileLogger.handler(label: label)
+        }
+
+        return stepLogger
+    }
 }

--- a/Sources/SwiftBuilder/Toolchain/ArchedLibToolchainComponent.swift
+++ b/Sources/SwiftBuilder/Toolchain/ArchedLibToolchainComponent.swift
@@ -17,7 +17,15 @@ final class ArchedLibToolchainComponent: ToolchaninComponent {
 
         let installFolder = config.installLocation(for: buildItem)
         let libsFolder = installFolder.appending(path: "lib/")
-        let libsSoFiles = try fileManager.categorizedFolderContent(at: libsFolder).files.filter { $0.pathExtension == "so" }
+        let allFilesInLib = try fileManager.categorizedFolderContent(at: libsFolder).files
+
+        // We have icu libs, which has symlinks, and I copy with them, because SONAME in lib actually *.so.65, not event .so.65.1
+        // So I will copy symlinks too
+        // If there will be an issue, we can patch elf files - here is answer from [stackoverflow](https://stackoverflow.com/questions/18467163/is-there-any-way-to-change-the-soname-of-a-binary-directly)
+        // We need patch SOANEM and some libs in NEEDED
+        let libsSoFiles = allFilesInLib.filter { fileUrl in
+            fileUrl.pathExtension == "so" || fileUrl.lastPathComponent.contains(".so.")
+        }
 
         for libsSoFile in libsSoFiles {
             let destination = destinationFolder.appending(path: libsSoFile.lastPathComponent)

--- a/Sources/SwiftBuilder/Utils/AutoconfSettings.swift
+++ b/Sources/SwiftBuilder/Utils/AutoconfSettings.swift
@@ -3,11 +3,11 @@ import Foundation
 
 extension BuildConfig {
     func clangPath(for arch: AndroidArch) -> String {
-        ndkToolchain + "/bin/\(arch.clangFilenamePrefix)\(androidApiLevel)-clang"
+        ndk.toolchainPath + "/bin/\(arch.clangFilenamePrefix)\(androidApiLevel)-clang"
     }
 
     func clangPpPath(for arch: AndroidArch) -> String {
-        ndkToolchain + "/bin/\(arch.clangFilenamePrefix)\(androidApiLevel)-clang++"
+        ndk.toolchainPath + "/bin/\(arch.clangFilenamePrefix)\(androidApiLevel)-clang++"
     }
 }
 

--- a/Sources/SwiftBuilder/Utils/StepProgressReporter.swift
+++ b/Sources/SwiftBuilder/Utils/StepProgressReporter.swift
@@ -3,6 +3,7 @@ import Foundation
 
 final class StepProgressReporter {
 
+    // TODO: Replace many states with "executing state" with string for console
     enum State {
         case configure
         case build

--- a/Sources/SwiftcAndroid/Arguments.swift
+++ b/Sources/SwiftcAndroid/Arguments.swift
@@ -18,9 +18,9 @@ struct Arguments {
             throw SimpleError("Failed to find `-target` in command arguments: \(commandArguments.joined(separator: " "))")
         }
 
-        let targetIndex = targetKeyIndex + 1
+        let targetIndex = commandArguments.index(after: targetKeyIndex)
 
-        guard commandArguments.count > targetIndex else {
+        guard commandArguments.endIndex > targetIndex else {
             throw SimpleError("Failed to find value for `-target` in command arguments: \(commandArguments.joined(separator: " "))")
         }
 

--- a/Sources/SwiftcAndroid/main.swift
+++ b/Sources/SwiftcAndroid/main.swift
@@ -23,9 +23,9 @@ let isArbitraryCall = CommandLine.argc == 2
 // Right now I found one mroe extra case `-modulewrap`. This is not compile operation.
 // I will do a trick here - if I can't see `.swift` in arguments, mean this is not a compile command, and I will not add anything
 // FIXME: I start thinking that this executable should not exist at all, we should be able to pass all needed parameters with `-Xswiftc`
-let isModeuleWrap = CommandLine.arguments.dropFirst().contains("-modulewrap")
+let isModuleWrap = CommandLine.arguments.dropFirst().contains("-modulewrap")
 
-let shouldEnrichCall = !isModeuleWrap && !isArbitraryCall
+let shouldEnrichCall = !modulewrap && !isArbitraryCall
 
 guard shouldEnrichCall else {
 

--- a/Sources/SwiftcAndroid/main.swift
+++ b/Sources/SwiftcAndroid/main.swift
@@ -66,22 +66,22 @@ if existeApiLevelParametr != nil {
     adnroidApiArgument = ["-Xcc", "-D__ANDROID_API__=\(String.androidApiLevel)"]
 }
 
-let ndkToolchainPath = host.ndk.toolchain.path(percentEncoded: false)
+//let ndkToolchainPath = host.ndk.toolchainPath
 
-let sysrootLibs = "\(ndkToolchainPath)/sysroot/usr/lib/\(arguments.target.ndkLibArchName)/\(String.androidApiLevel)"
+let sysrootLibs = "\(host.ndk.sysrootLibPath)/\(arguments.target.ndkLibArchName)/\(String.androidApiLevel)"
 
 let extraArguments: [String] = [
-    "-tools-directory", "\(ndkToolchainPath)/bin",
+    "-tools-directory", "\(host.ndk.toolchainPath)/bin",
     "-Xclang-linker", "--sysroot=\(sysrootLibs)",
-    "-Xclang-linker", "--gcc-toolchain=\(ndkToolchainPath)",
+    "-Xclang-linker", "--gcc-toolchain=\(host.ndk.toolchainPath)",
 
     // Here is explanation, that we need -B with path passed to linker, so it will search for crtbegin + crtend
     // https://github.com/android/ndk/issues/1690#issuecomment-1529928723
     "-Xclang-linker", "-B",
     "-Xclang-linker", "\(sysrootLibs)",
 
-    "-Xcc", "-I\(ndkToolchainPath)/sysroot/usr/include",
-    "-Xcc", "-I\(ndkToolchainPath)/sysroot/usr/include/\(arguments.target.ndkLibArchName)",
+    "-Xcc", "-I\(host.ndk.toolchain)",
+    "-Xcc", "-I\(host.ndk.sysrootIncludePath)/\(arguments.target.ndkLibArchName)",
     "-L", "\(toolchainRootFolderPath)/usr/lib/swift/android/\(arguments.target.swiftArch)",
     "-L", "\(sysrootLibs)",
 ] + adnroidApiArgument

--- a/Sources/SwiftcAndroid/main.swift
+++ b/Sources/SwiftcAndroid/main.swift
@@ -20,12 +20,12 @@ let currentDirectoryURL = URL(filePath: fileManager.currentDirectoryPath, direct
 // Lets move this away from our path
 let isArbitraryCall = CommandLine.argc == 2
 
-// Right now I found one mroe extra case `-modulewrap`. This is not compile operation.
+// Right now I found one more extra case `-modulewrap`. This is not compile operation.
 // I will do a trick here - if I can't see `.swift` in arguments, mean this is not a compile command, and I will not add anything
 // FIXME: I start thinking that this executable should not exist at all, we should be able to pass all needed parameters with `-Xswiftc`
 let isModuleWrap = CommandLine.arguments.dropFirst().contains("-modulewrap")
 
-let shouldEnrichCall = !modulewrap && !isArbitraryCall
+let shouldEnrichCall = !isModuleWrap && !isArbitraryCall
 
 guard shouldEnrichCall else {
 


### PR DESCRIPTION
This PR follow steps from [plan here](https://github.com/NikolayJuly/swift-toolchain-for-android-on-macos/issues/1)

To make a full automation, I would like to run binary in emulator to make sure that it runs and check output of this command.
In Ideal scenario there should be also dynamic lib, which also will do test output, so I can be sure that I can build app + dynamic lib, even tho most likely dylib is only products which will be used

Whats left:
- [x] Understand why `libFoundation.so` depends on `libicudata.so.65` and not on `libicudata.so`, we had only correct one in install fodler
- [x] As tmp solution for so.65 - create symlink, not a copy of the same file and make sure it works. Will save size of app for now
- [x] Add step, which run emulator and pushes all needed dependencies there
- [x] Run executable in emulator and check output
- [x] Be able to stop emulator
- [x] Looks like on first call `adb` make connect, so ideally need to check that service is running and connected to localhost